### PR TITLE
Simplify secrets handling for kubevirt wizard

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.tsx
@@ -35,12 +35,12 @@ import { append, arrayItemHasKey, getName, setAvailableConnections } from './con
 import aiTemplate from './templates/assisted-installer/ai-template.hbs'
 import cimTemplate from './templates/assisted-installer/cim-template.hbs'
 import hypershiftTemplate from './templates/assisted-installer/hypershift-template.hbs'
-import kubevirtTemplate from './templates/assisted-installer/kubevirt-template.hbs'
 import nutanixAiTemplate from './templates/assisted-installer/nutanix-ai-template.hbs'
 import nutanixCimTemplate from './templates/assisted-installer/nutanix-cim-template.hbs'
 import clusterCuratorTemplate from './templates/cluster-curator.hbs'
 import endpointTemplate from './templates/endpoints.hbs'
 import hiveTemplate from './templates/hive-template.hbs'
+import kubevirtTemplate from './templates/kubevirt-template.hbs'
 import { Warning, WarningContext, WarningContextType } from './Warning'
 
 import jsyaml from 'js-yaml'
@@ -59,7 +59,7 @@ import getControlDataAZR from './controlData/ControlDataAZR'
 import getControlDataCIM from './controlData/ControlDataCIM'
 import getControlDataGCP from './controlData/ControlDataGCP'
 import getControlDataHypershift from './controlData/ControlDataHypershift'
-import { getControlDataKubeVirt, onChangeKubeVirtConnection } from './controlData/ControlDataKubeVirt'
+import { getControlDataKubeVirt } from './controlData/ControlDataKubeVirt'
 import getControlDataOST from './controlData/ControlDataOST'
 import getControlDataVMW from './controlData/ControlDataVMW'
 import './style.css'
@@ -148,24 +148,8 @@ export default function CreateCluster(props: { infrastructureType: ClusterInfras
     (control: any) => {
       if (control.id === 'connection') {
         if (newSecret && control.setActive) {
-          const secretName = newSecret?.metadata.name ?? ''
-          if (control.providerId === 'kubevirt') {
-            // preset replacement fields to get around delayed control state from setAvailableConnections
-            control.availableMap[secretName] = {
-              replacements: {
-                pullSecret: newSecret.data?.pullSecret ?? '',
-                'ssh-publickey': newSecret.data?.['ssh-publickey'] ?? '',
-                kubeconfig: newSecret.data?.kubeconfig ?? '',
-                externalInfraNamespace: newSecret.data?.externalInfraNamespace ?? '',
-                encoded: true,
-              },
-            }
-          }
-          control.setActive(secretName)
+          control.setActive(newSecret.metadata.name)
           setNewSecret(undefined) // override with the new secret once
-        }
-        if (!newSecret && control.providerId === 'kubevirt') {
-          onChangeKubeVirtConnection(control)
         }
         setSelectedConnection(providerConnections.find((provider) => control.active === provider.metadata.name))
       } else if (control.id === 'kubevirt-operator-alert') {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
@@ -244,9 +244,9 @@ export const setAvailableConnections = (control, secrets) => {
   control.available = connections.map((secret) => secret.metadata.name).sort((a, b) => a.localeCompare(b))
   const perPostSection = control.groupControlData?.find(({ id }) => id === 'perPostSection')
   if (
-    Array.isArray(control.providerId)
-      ? !control.providerId.some((provider) => ['hostinventory', 'nutanix', 'kubevirt'].includes(provider))
-      : !['hostinventory', 'nutanix', 'kubevirt'].includes(control.providerId)
+    !(Array.isArray(control.providerId) ? control.providerId : [control.providerId]).some((provider) =>
+      ['hostinventory', 'nutanix'].includes(provider)
+    )
   ) {
     // unset default ansible secret for subscription wizard as it's not required
     if (control.setActive && !control.active && !perPostSection) {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataKubeVirt.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataKubeVirt.js
@@ -12,6 +12,7 @@ import {
   LOAD_ETCD_CLASSES,
   LOAD_OCP_IMAGES,
   numberedControlNameFunction,
+  onChangeConnection,
   onImageChange,
   reverseImageSet,
   reverseStorageClass,
@@ -42,28 +43,6 @@ const operatorAlert = (localCluster, t) => {
       </div>
     </Alert>
   )
-}
-
-export const onChangeKubeVirtConnection = (control) => {
-  const { active, availableMap = {} } = control
-  const replacements = get(availableMap[active], 'replacements')
-  const isEncoded = replacements?.encoded && replacements?.encoded === true
-  const activePullSecret = replacements?.pullSecret ?? ''
-  const activeSSHKey = replacements?.['ssh-publickey'] ?? ''
-  const activeKubeconfig = replacements?.kubeconfig ?? ''
-  const activeExternalInfraNamespace = replacements?.externalInfraNamespace ?? ''
-
-  if (active && !isEncoded && activePullSecret !== '') {
-    control.availableMap[active] = {
-      replacements: {
-        kubeconfig: Buffer.from(activeKubeconfig, 'ascii').toString('base64'),
-        externalInfraNamespace: activeExternalInfraNamespace,
-        pullSecret: Buffer.from(activePullSecret, 'ascii').toString('base64'),
-        'ssh-publickey': Buffer.from(activeSSHKey, 'ascii').toString('base64'),
-        encoded: true,
-      },
-    }
-  }
 }
 
 export const getControlDataKubeVirt = (
@@ -113,8 +92,7 @@ export const getControlDataKubeVirt = (
       },
       available: [],
       footer: <CreateCredentialModal handleModalToggle={handleModalToggle} />,
-      onSelect: onChangeKubeVirtConnection,
-      encode: ['pullSecret', 'sshPublicKey', 'kubeconfig'],
+      onSelect: onChangeConnection,
       hasReplacements: true,
     },
     {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/kubevirt-template.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/kubevirt-template.hbs
@@ -65,9 +65,10 @@ kind: Secret
 metadata:
   name: infra-cluster-{{{clusterName}}}
   namespace: 'clusters'
-data:
+stringData:
 {{#if showSecrets}}  
-  kubeconfig: {{{kubeconfig}}}
+  kubeconfig: |-
+    {{{kubeconfig}}}
   {{else}}
   kubeconfig: #injected on create
 {{/if}}
@@ -77,11 +78,12 @@ kind: Secret
 metadata:
   name: pullsecret-cluster-{{{clusterName}}}
   namespace: clusters
-data:
+stringData:
   {{#if showSecrets}}
-  '.dockerconfigjson': {{{pullSecret}}}
+  .dockerconfigjson: |-
+    {{{pullSecret}}}
   {{else}}
-  '.dockerconfigjson': #injected on create
+  .dockerconfigjson: #injected on create
   {{/if}}
 type: kubernetes.io/dockerconfigjson
 
@@ -91,7 +93,7 @@ kind: Secret
 metadata:
   name: sshkey-cluster-{{{clusterName}}}
   namespace: 'clusters'
-data:
+stringData:
   {{#if showSecrets}}
   id_rsa.pub: {{{ssh-publickey}}}
   {{else}}


### PR DESCRIPTION
1. Enables auto-credential selection for kubevirt when you enter the wizard
2. Moves `kubevirt-template.hbs` to not be located with `assisted-installer` templates.
3. Converts `kubevirt-template.hbs` to use `stringData` so that users can see their secrets if they choose (not base64-encoded) and removes a lot of custom code for enconding/decoding for this wizard.