### PR TITLE
Scope clickRowAction to within the table

### DIFF
--- a/frontend/src/lib/test-util.ts
+++ b/frontend/src/lib/test-util.ts
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { act, ByRoleMatcher, ByRoleOptions, screen, waitFor } from '@testing-library/react'
+import { act, ByRoleMatcher, ByRoleOptions, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Scope } from 'nock/types'
 
@@ -355,8 +355,11 @@ export async function clickBulkAction(text: string) {
   await clickByText(text)
 }
 
-export async function clickRowAction(row: number, text: string) {
-  await clickByLabel('Actions', row - 1)
+export async function clickRowAction(row: number, text: string, table = 'Simple Table') {
+  await waitForRole('grid', { name: table })
+  within(screen.getByRole('grid', { name: table }))
+    .getAllByLabelText('Actions')
+    [row - 1].click()
   await clickByText(text)
 }
 

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomations.test.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomations.test.tsx
@@ -27,6 +27,7 @@ import {
   clickBulkAction,
   clickByLabel,
   clickByText,
+  clickRowAction,
   getCSVDownloadLink,
   getCSVExportSpies,
   selectTableRow,
@@ -210,8 +211,7 @@ describe('Automations page', () => {
     const deleteNock = nockDelete(clusterCurator2)
     render(<TestIntegrationPage providerConnections={mockProviderConnections} clusterCurators={clusterCurators} />)
     await waitForText(clusterCurator2.metadata!.name!)
-    await clickByLabel('Actions', 1) // Click the action button on the first table row
-    await clickByText('Delete')
+    await clickRowAction(1, 'Delete')
     await clickByText('Delete')
     await waitForNock(deleteNock)
   })
@@ -220,8 +220,7 @@ describe('Automations page', () => {
     const badRequestStatus = nockDelete(clusterCurator2, mockBadRequestStatus)
     render(<TestIntegrationPage providerConnections={mockProviderConnections} clusterCurators={clusterCurators} />)
     await waitForText(clusterCurator2.metadata!.name!)
-    await clickByLabel('Actions', 1) // Click the action button on the first table row
-    await clickByText('Delete')
+    await clickRowAction(1, 'Delete')
     await clickByText('Delete')
     await waitForNock(badRequestStatus)
     await waitForText(`Could not process request because of invalid data.`)
@@ -230,8 +229,7 @@ describe('Automations page', () => {
   test('should be able to cancel delete a template', async () => {
     render(<TestIntegrationPage providerConnections={mockProviderConnections} clusterCurators={clusterCurators} />)
     await waitForText(clusterCurator2.metadata!.name!)
-    await clickByLabel('Actions', 1) // Click the action button on the first table row
-    await clickByText('Delete')
+    await clickRowAction(1, 'Delete')
     await clickByText('Cancel')
     await waitForNotText('Cancel')
   })

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/ClusterPools.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/ClusterPools.tsx
@@ -522,7 +522,7 @@ export function ClusterPoolsTable(props: {
                     id={`${clusterPool.metadata.name}-actions`}
                     item={clusterPool}
                     isKebab={true}
-                    text={`${clusterPool.metadata.name}-actions`}
+                    text={t('Actions')}
                     actions={actions}
                   />
                 )


### PR DESCRIPTION
Scopes the clickRowAction function to within a table and fixes a few of the tests.

Note that if we ever fix https://issues.redhat.com/browse/ACM-5264, we'll have to update this implementation to remove the hard-coded 'Simple Table' aria-label and update these tests to use an appropriate label. I've made a note of this on the issue as well.