### PR TITLE
Suggested fixes

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -3133,7 +3133,7 @@
   "True": "True",
   "Type": "Type",
   "type.to.confirm": "Confirm by typing \"{{confirm}}\" below:",
-  "type.trialVersionOf": "Trial version of",
+  "type.trialVersionOf": "Trial version of {{product}}",
   "Unable to communicate with the server because of a bad gateway.": "Unable to communicate with the server because of a bad gateway.",
   "Unable to communicate with the server because of a network error.": "Unable to communicate with the server because of a network error.",
   "Unable to communicate with the server because of an unexpected error.": "Unable to communicate with the server because of an unexpected error.",

--- a/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveryConfig/discoveryConfigFilters.test.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveryConfig/discoveryConfigFilters.test.ts
@@ -1,4 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
+import i18n from '../../../../../lib/i18n'
 import { Provider } from '../../../../../ui-components'
 import {
   getInfrastructureProvider,
@@ -13,6 +14,8 @@ import {
   INFRASTRUCTURE_PROVIDERS,
   getDisplayNameForInfrastructureProvider,
 } from './discoveryConfigFilters'
+
+const t = i18n.t.bind(i18n)
 
 // Testing getDisplayNameForInfrastructureProvider function
 describe('getDisplayNameForInfrastructureProvider', () => {
@@ -190,53 +193,53 @@ describe('searchInfrastructureProvider', () => {
 // Testing getFullTypeByAcronymForDiscoveryClustersType function
 describe('getFullTypeByAcronymForDiscoveryClustersType', () => {
   it('returns correct translated type for MOA', () => {
-    expect(getFullTypeByAcronymForDiscoveryClustersType('MOA')).toBe('Red Hat OpenShift Service on AWS')
+    expect(getFullTypeByAcronymForDiscoveryClustersType('MOA', t)).toBe('Red Hat OpenShift Service on AWS')
   })
 
   it('returns correct translated type for MOA-HostedControlPlane', () => {
-    expect(getFullTypeByAcronymForDiscoveryClustersType('MOA-HostedControlPlane')).toBe(
+    expect(getFullTypeByAcronymForDiscoveryClustersType('MOA-HostedControlPlane', t)).toBe(
       'Red Hat OpenShift Service on AWS Hosted Control Plane'
     )
   })
 
   it('returns correct translated type for ROSA', () => {
-    expect(getFullTypeByAcronymForDiscoveryClustersType('ROSA')).toBe('Red Hat OpenShift Service on AWS')
+    expect(getFullTypeByAcronymForDiscoveryClustersType('ROSA', t)).toBe('Red Hat OpenShift Service on AWS')
   })
 
   it('returns correct translated type for ROSA-HyperShift', () => {
-    expect(getFullTypeByAcronymForDiscoveryClustersType('ROSA-HyperShift')).toBe(
+    expect(getFullTypeByAcronymForDiscoveryClustersType('ROSA-HyperShift', t)).toBe(
       'Red Hat OpenShift Service on AWS Hosted Control Plane'
     )
   })
 
   it('returns correct translated type for OCP-AssistedInstall', () => {
-    expect(getFullTypeByAcronymForDiscoveryClustersType('OCP-AssistedInstall')).toBe(
+    expect(getFullTypeByAcronymForDiscoveryClustersType('OCP-AssistedInstall', t)).toBe(
       'OpenShift Container Platform (Assisted Installer)'
     )
   })
 
   it('returns correct translated type for OCP', () => {
-    expect(getFullTypeByAcronymForDiscoveryClustersType('OCP')).toBe('OpenShift Container Platform')
+    expect(getFullTypeByAcronymForDiscoveryClustersType('OCP', t)).toBe('OpenShift Container Platform')
   })
 
   it('returns correct translated type for OSD', () => {
-    expect(getFullTypeByAcronymForDiscoveryClustersType('OSD')).toBe('OpenShift Dedicated')
+    expect(getFullTypeByAcronymForDiscoveryClustersType('OSD', t)).toBe('OpenShift Dedicated')
   })
 
   it('returns correct translated type for OSDTrial', () => {
-    expect(getFullTypeByAcronymForDiscoveryClustersType('OSDTrial')).toBe('Trial version of OpenShift Dedicated')
+    expect(getFullTypeByAcronymForDiscoveryClustersType('OSDTrial', t)).toBe('Trial version of OpenShift Dedicated')
   })
 
   it('returns correct translated type for ARO', () => {
-    expect(getFullTypeByAcronymForDiscoveryClustersType('ARO')).toBe('Azure Red Hat OpenShift')
+    expect(getFullTypeByAcronymForDiscoveryClustersType('ARO', t)).toBe('Azure Red Hat OpenShift')
   })
 
   it('returns correct translated type for RHMI', () => {
-    expect(getFullTypeByAcronymForDiscoveryClustersType('RHMI')).toBe('Red Hat Managed Integration')
+    expect(getFullTypeByAcronymForDiscoveryClustersType('RHMI', t)).toBe('Red Hat Managed Integration')
   })
 
   it('returns correct translated type for RHOIC', () => {
-    expect(getFullTypeByAcronymForDiscoveryClustersType('RHOIC')).toBe('Red Hat OpenShift on IBM Cloud')
+    expect(getFullTypeByAcronymForDiscoveryClustersType('RHOIC', t)).toBe('Red Hat OpenShift on IBM Cloud')
   })
 })
 
@@ -348,26 +351,6 @@ describe('Cluster type group functions', () => {
     it('returns empty array for unknown groups', () => {
       expect(getAllClusterTypesFromGroups(['UNKNOWN'])).toEqual([])
     })
-  })
-})
-
-describe('getFullTypeByAcronymForDiscoveryClustersType with translation function', () => {
-  it('uses translation function when provided', () => {
-    const mockTranslate = jest.fn((key) => key)
-
-    expect(getFullTypeByAcronymForDiscoveryClustersType('OSDTrial', mockTranslate)).toBe('type.trialVersionOf')
-    expect(mockTranslate).toHaveBeenCalledWith('type.trialVersionOf', { product: 'OpenShift Dedicated' })
-  })
-
-  it('handles interpolation with translation function', () => {
-    const mockTranslate = jest.fn((key, params) => {
-      if (key === 'type.trialVersionOf' && params?.product) {
-        return `TEST: ${params.product}`
-      }
-      return key
-    })
-
-    expect(getFullTypeByAcronymForDiscoveryClustersType('OSDTrial', mockTranslate)).toBe('TEST: OpenShift Dedicated')
   })
 })
 

--- a/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveryConfig/discoveryConfigFilters.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveryConfig/discoveryConfigFilters.ts
@@ -1,5 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
+import { TFunction } from 'i18next'
 import { Provider } from '../../../../../ui-components'
 
 export type TranslationFunction = (key: string, params?: Record<string, string>) => string
@@ -146,7 +147,7 @@ export function searchInfrastructureProvider(provider: string) {
  * @returns The full display name of the cluster type, or the original acronym if not recognized
  */
 
-export function getFullTypeByAcronymForDiscoveryClustersType(acronym: string, t?: TranslationFunction) {
+export function getFullTypeByAcronymForDiscoveryClustersType(acronym: string, t: TFunction) {
   switch (acronym.toUpperCase()) {
     case 'MOA':
       return 'Red Hat OpenShift Service on AWS'
@@ -163,7 +164,7 @@ export function getFullTypeByAcronymForDiscoveryClustersType(acronym: string, t?
     case 'OSD':
       return 'OpenShift Dedicated'
     case 'OSDTRIAL':
-      return t ? t('type.trialVersionOf', { product: 'OpenShift Dedicated' }) : 'Trial version of OpenShift Dedicated'
+      return t('type.trialVersionOf', { product: 'OpenShift Dedicated' })
     case 'ARO':
       return 'Azure Red Hat OpenShift'
     case 'RHMI':


### PR DESCRIPTION
- Fix string for trial version interpolation
- Remove test affordances from product code

By testing with the actual translation, we ensure interpolation is set up correctly. By making the `t` function parameter required instead of optional, we make sure we don't have product code accidentally forgetting to pass the `t` function.
